### PR TITLE
We use outdated docker and we may need to use legacy golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine3.7 as builder
+FROM golang:1.10-alpine3.7 as builder
 
 RUN apk add --no-cache curl git
 COPY . /go/src/github.com/anchorfree/s3sync


### PR DESCRIPTION
I could not fid the reason except that we switched over to 1.11 